### PR TITLE
deps: bump versions for v2.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/CosmWasm/wasmd v0.30.0
-	github.com/classic-terra/core/v2 v2.2.1
+	github.com/classic-terra/core/v2 v2.3.0
 	github.com/cometbft/cometbft-db v0.7.0
 	github.com/cosmos/cosmos-sdk v0.46.14
 	github.com/cosmos/iavl v0.19.7
@@ -180,15 +180,15 @@ replace (
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/jhump/protoreflect => github.com/jhump/protoreflect v1.9.0
-	// replace broken goleveldb.
-	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )
 
 replace (
 	github.com/CosmWasm/wasmd => github.com/classic-terra/wasmd v0.30.0-terra.3
 	github.com/CosmWasm/wasmvm => github.com/classic-terra/wasmvm v1.1.1-terra.1
-	github.com/cosmos/cosmos-sdk => github.com/classic-terra/cosmos-sdk v0.46.14-terra.2
+	github.com/cosmos/cosmos-sdk => github.com/classic-terra/cosmos-sdk v0.46.14-terra.4
 	github.com/cosmos/ledger-cosmos-go => github.com/terra-money/ledger-terra-go v0.11.2
+	// replace goleveldb to optimized one
+	github.com/syndtr/goleveldb => github.com/classic-terra/goleveldb v0.0.0-20230914223247-2b28f6655121
 	github.com/tendermint/tendermint => github.com/classic-terra/cometbft v0.34.29-terra.0
 	github.com/tendermint/tm-db => github.com/terra-money/tm-db v0.6.7-performance.3
 )

--- a/go.sum
+++ b/go.sum
@@ -334,8 +334,14 @@ github.com/classic-terra/cometbft v0.34.29-terra.0 h1:HnRGt7tijI2n5zSVrg/xh1mYYm
 github.com/classic-terra/cometbft v0.34.29-terra.0/go.mod h1:L9shMfbkZ8B+7JlwANEr+NZbBcn+hBpwdbeYvA5rLCw=
 github.com/classic-terra/core/v2 v2.2.1 h1:82mRHeyUXtuvnZalCrSq1jf07KAa9JIt+bSmFkJezzk=
 github.com/classic-terra/core/v2 v2.2.1/go.mod h1:JsVGRohOyq4ipfF/yuo/xitkeMipoXpn0E8tmV3fXyE=
+github.com/classic-terra/core/v2 v2.3.0 h1:JMzCFNsXVeBSvtvLvr2+rlQPRjgmJ/kJJpT7595ZJ5M=
+github.com/classic-terra/core/v2 v2.3.0/go.mod h1:jUFX4udANShhFU45GvYwqZK2ZyOlpibA77fsaZ4SJXs=
 github.com/classic-terra/cosmos-sdk v0.46.14-terra.2 h1:TRuTbrbBMYOFg59G0WHjvIGu9Daf3gO6PoghlLAFQd0=
 github.com/classic-terra/cosmos-sdk v0.46.14-terra.2/go.mod h1:tx+Rr8Fob/HQ8iErtht7Rddu1FrMg2KBQl9anicuxsQ=
+github.com/classic-terra/cosmos-sdk v0.46.14-terra.4 h1:GRgKTxC5n+5CqxtqkoJ+fNwGO4y+F9UATvolzfhEc38=
+github.com/classic-terra/cosmos-sdk v0.46.14-terra.4/go.mod h1:3VKRzlOtvuqZA29wRqdx6rPsJmYhvxjJyc3tvQWpjf4=
+github.com/classic-terra/goleveldb v0.0.0-20230914223247-2b28f6655121 h1:fjpWDB0hm225wYg9vunyDyTH8ftd5xEUgINJKidj+Tw=
+github.com/classic-terra/goleveldb v0.0.0-20230914223247-2b28f6655121/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/classic-terra/wasmd v0.30.0-terra.3 h1:qruhiaAIRl14UVtHzfh81pr0YmW94QE4+hqivIi9AYg=
 github.com/classic-terra/wasmd v0.30.0-terra.3/go.mod h1:Ug607EsX+EkW3/xOFaP56kZA7WklN+ZrwUEsaJ22xH0=
 github.com/classic-terra/wasmvm v1.1.1-terra.1 h1:qGozlXFlM/3ossnlABwODJr7bEHUdF/nug8Z3c1Dr84=


### PR DESCRIPTION
Bump versions for v2.3.0 upgrade of terrad (including v2.2.2 bumps)