### PR TITLE
fix: initialize store metrics to prevent nil pointer panic

### DIFF
--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -94,6 +94,7 @@ func NewStore(db cmtdb.DB, logger cmtlog.Logger, hldb *hld.HeightLimitedDB) *Sto
 		listeners:           make(map[types.StoreKey]*types.MemoryListener),
 		removalMap:          make(map[types.StoreKey]bool),
 		pruningManager:      pruning.NewManager(cosmosDB, sdklog.NewNopLogger()),
+		metrics:             metrics.NewNoOpMetrics(),
 	}
 }
 


### PR DESCRIPTION
rootmulti.NewStore() never initializes the metrics field, leaving it as nil. This value is passed to iavl.LoadStore() which stores it directly. Every IAVL operation (Get, Set, Has, Commit, etc.) calls st.metrics.MeasureSince(...) — a nil pointer dereference that panics on startup.